### PR TITLE
Issue 10

### DIFF
--- a/lib/recode/ast.ex
+++ b/lib/recode/ast.ex
@@ -220,7 +220,6 @@ defmodule Recode.AST do
     end
   end
 
-  # {alias :: module(), multi :: [module()], as :: nil | module()}
   @doc """
   Returns the infos from an AST representing an `alias` expression.
 
@@ -247,6 +246,7 @@ defmodule Recode.AST do
       iex> alias_info(ast)
       {Foo, [], Baz}
   """
+  @spec alias_info(Macro.t()) :: {module(), [module()], module() | nil}
   def alias_info({:alias, _meta1, [{:__aliases__, _meta2, aliases}]}) do
     module = Module.concat(aliases)
     {module, [], nil}

--- a/lib/recode/config.ex
+++ b/lib/recode/config.ex
@@ -27,7 +27,7 @@ defmodule Recode.Config do
     |> read()
   end
 
-  def default(config, :tasks) do
+  defp default(config, :tasks) do
     Keyword.update!(config, :tasks, fn tasks -> [{Format, []} | tasks] end)
   end
 end

--- a/lib/recode/debug_info.ex
+++ b/lib/recode/debug_info.ex
@@ -8,6 +8,8 @@ defmodule Recode.DebugInfo do
   alias Recode.Context
   alias Sourceror.Zipper
 
+  @spec expand_mfa(map(), Context.t(), {module() | nil, atom(), non_neg_integer()}) ::
+          {:ok, mfa()} | :error
   def expand_mfa(debug_info, context, {_module, fun, arity} = mfa) do
     with {:ok, definitions} <- Map.fetch(debug_info, :definitions),
          {:ok, block} <- find_block(definitions, context) do

--- a/lib/recode/formatter.ex
+++ b/lib/recode/formatter.ex
@@ -21,6 +21,11 @@ defmodule Recode.Formatter do
               opts :: keyword()
             ) :: any()
 
+  @spec format(
+          type :: :project | :results | :tasks_ready,
+          {Project.t(), config :: keyword()},
+          opts :: keyword()
+        ) :: any()
   def format(:results, {%Project{} = project, config}, opts) do
     verbose = Keyword.fetch!(config, :verbose)
 
@@ -46,6 +51,12 @@ defmodule Recode.Formatter do
     end
   end
 
+  @spec format(
+          type :: :task,
+          {Project.t(), config :: keyword()},
+          {Source.t(), module, keyword()},
+          opts :: keyword()
+        ) :: any()
   def format(:task, {_project, _config}, {_source, _task_module, _task_opts}, _opts) do
     write(".")
   end

--- a/lib/recode/io.ex
+++ b/lib/recode/io.ex
@@ -24,9 +24,12 @@ defmodule Recode.IO do
     warn: :orange
   }
 
+  @type chardata :: String.t() | maybe_improper_list(char | chardata, String.t() | [])
+
   @doc """
   Similar `to write/1`, but adds a newline at the end.
   """
+  @spec puts(chardata()) :: :ok
   def puts(chardata) do
     chardata
     |> Enum.map(&colors/1)
@@ -37,6 +40,7 @@ defmodule Recode.IO do
   Formats a chardata-like argument by converting named ANSI sequences into
   actual ANSI codes and writes it to `:stdio`.
   """
+  @spec write(chardata()) :: :ok
   def write(chardata) when is_list(chardata) do
     chardata
     |> Enum.map(&colors/1)

--- a/lib/recode/issue.ex
+++ b/lib/recode/issue.ex
@@ -15,6 +15,7 @@ defmodule Recode.Issue do
           meta: term()
         }
 
+  @spec new(module(), String.t() | nil, keyword(), term()) :: Issue.t()
   def new(reporter, message, info \\ [], meta \\ nil) do
     line = Keyword.get(info, :line)
     column = Keyword.get(info, :column)

--- a/lib/recode/project.ex
+++ b/lib/recode/project.ex
@@ -44,6 +44,7 @@ defmodule Recode.Project do
   @doc ~S"""
   Creates a `%Project{}` from the given sources.
   """
+  @spec from_sources([Source.t()]) :: Project.t()
   def from_sources(sources) do
     {sources, paths} =
       Enum.reduce(sources, {%{}, %{}}, fn source, {sources, paths} ->

--- a/lib/recode/task/alias_expansion.ex
+++ b/lib/recode/task/alias_expansion.ex
@@ -19,6 +19,7 @@ defmodule Recode.Task.AliasExpansion do
   alias Recode.Task.AliasExpansion
   alias Sourceror.Zipper
 
+  @impl Recode.Task
   def run(source, opts) do
     {zipper, issues} =
       source

--- a/lib/recode/task/alias_order.ex
+++ b/lib/recode/task/alias_order.ex
@@ -23,6 +23,7 @@ defmodule Recode.Task.AliasOrder do
   alias Recode.Task.AliasOrder
   alias Sourceror.Zipper
 
+  @impl Recode.Task
   def run(source, opts) do
     do_run(source, opts[:autocorrect])
   end

--- a/lib/recode/task/format.ex
+++ b/lib/recode/task/format.ex
@@ -12,6 +12,7 @@ defmodule Recode.Task.Format do
   alias Recode.Source
   alias Recode.Task.Format
 
+  @impl Recode.Task
   def run(source, opts) do
     format(source, opts[:autocorrect])
   end

--- a/lib/recode/task/pipe_fun_one.ex
+++ b/lib/recode/task/pipe_fun_one.ex
@@ -18,6 +18,7 @@ defmodule Recode.Task.PipeFunOne do
   alias Recode.Task.PipeFunOne
   alias Sourceror.Zipper
 
+  @impl Recode.Task
   def run(source, opts) do
     {zipper, issues} =
       source

--- a/lib/recode/task/single_pipe.ex
+++ b/lib/recode/task/single_pipe.ex
@@ -19,6 +19,7 @@ defmodule Recode.Task.SinglePipe do
   alias Recode.Task.SinglePipe
   alias Sourceror.Zipper
 
+  @impl Recode.Task
   def run(source, opts) do
     {zipper, issues} =
       source

--- a/lib/recode/task/specs.ex
+++ b/lib/recode/task/specs.ex
@@ -14,6 +14,7 @@ defmodule Recode.Task.Specs do
   alias Recode.Source
   alias Recode.Task.Specs
 
+  @impl Recode.Task
   def run(source, opts) do
     include = Keyword.get(opts, :only, :all)
     issues = check_specs(source, include)
@@ -41,7 +42,13 @@ defmodule Recode.Task.Specs do
     end
   end
 
-  defp check_spec(_only, %Context{definition: nil}, issues), do: issues
+  defp check_spec(_only, %Context{definition: nil}, issues) do
+    issues
+  end
+
+  defp check_spec(_only, %Context{definition: {{:defmacro, :__using__, _args}, _body}}, issues) do
+    issues
+  end
 
   defp check_spec(:all, context, issues) do
     case Context.spec?(context) do

--- a/lib/recode/task/test_file_ext.ex
+++ b/lib/recode/task/test_file_ext.ex
@@ -12,6 +12,7 @@ defmodule Recode.Task.TestFileExt do
   alias Recode.Source
   alias Recode.Task.TestFileExt
 
+  @impl Recode.Task
   def run(source, opts) do
     test_file_ext(source, opts[:autocorrect])
   end

--- a/recode.exs
+++ b/recode.exs
@@ -1,0 +1,25 @@
+alias Recode.Task
+
+# A recode config to run recode with recode. This config excludes the test
+# directory.
+
+[
+  # Can also be set/reset with "--autocorrect"/"--no-autocorrect".
+  autocorrect: true,
+  # With "--dry" no changes will be written to the files.
+  # Can also be set/reset with "--dry"/"--no-dry".
+  # If dry is true then verbose is also active.
+  dry: false,
+  # Can also be set/reset with "--verbose"/"--no-verbose".
+  verbose: false,
+  inputs: ["{config,lib}/**/*.{ex,exs}"],
+  formatter: {Recode.Formatter, []},
+  tasks: [
+    {Task.AliasExpansion, []},
+    {Task.AliasOrder, []},
+    {Task.PipeFunOne, []},
+    {Task.SinglePipe, []},
+    {Task.Specs, [only: :visible, exclude: "test/**/*.{ex,exs}"]},
+    {Task.TestFileExt, []}
+  ]
+]

--- a/test/fixtures/context/vars.ex
+++ b/test/fixtures/context/vars.ex
@@ -1,0 +1,21 @@
+defmodule Vars do
+  def vars do
+    alias = "alias"
+    import = "import"
+    require = "require"
+    use = "use"
+    defimpl = "defimpl"
+    def = "def"
+  end
+
+  def vars(x) do
+    alias = identity(x)
+    import = identity(x)
+    require = identity(x)
+    use = identity(x)
+    defimpl = identity(x)
+    def = identity(x)
+  end
+
+  defp identity(x), do: x
+end

--- a/test/fixtures/context/vars.exs
+++ b/test/fixtures/context/vars.exs
@@ -1,0 +1,5 @@
+alias = "alias"
+import = "import"
+require = "require"
+use = "use"
+defimpl = "defimpl"

--- a/test/recode/context_test.exs
+++ b/test/recode/context_test.exs
@@ -178,6 +178,48 @@ defmodule Recode.ContextTest do
              end_of_expression: [newlines: 2, line: 24, column: 38], line: 24, column: 3], nil}]\
              """
     end
+
+    test "traveses script with vars named alias, import, etc.." do
+      src = File.read!("test/fixtures/context/vars.exs")
+
+      output =
+        capture_io(fn ->
+          src
+          |> Sourceror.parse_string!()
+          |> Zipper.zip()
+          |> Context.traverse(fn zipper, context ->
+            context =
+              context
+              |> inc()
+              |> write()
+
+            {zipper, context}
+          end)
+        end)
+
+      assert output |> String.split("\n") |> Enum.count() == 221
+    end
+
+    test "traveses module with vars named alias, import, etc.." do
+      src = File.read!("test/fixtures/context/vars.ex")
+
+      output =
+        capture_io(fn ->
+          src
+          |> Sourceror.parse_string!()
+          |> Zipper.zip()
+          |> Context.traverse(fn zipper, context ->
+            context =
+              context
+              |> inc()
+              |> write()
+
+            {zipper, context}
+          end)
+        end)
+
+      assert output |> String.split("\n") |> Enum.count() == 848
+    end
   end
 
   describe "traverse/3" do


### PR DESCRIPTION
Closes #10 

A variable called `import` was handled as the command `import`.

Added `recode.exs` to run `recode` with `recode`:
```shell
$ mix recode --dry --config recode.exs
Found 28 files, including 0 scripts.
....................................................................................................................................................................................................
```