### PR TITLE
Adds unused dependencies check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
         run: MIX_ENV=test mix deps.compile
       - name: Compile project
         run: MIX_ENV=test mix compile --warnings-as-errors
+      - name: Check unused dependencies
+        run: mix deps.unlock --check-unused
       - name: Check code format
         if: ${{ contains(matrix.elixir, '1.14.0') && contains(matrix.otp, '25.0') }}
         run: MIX_ENV=test mix format --check-formatted


### PR DESCRIPTION
This PR adds a new step to CI to ensure no unused dependency is locked by `mix.lock`.