### PR TITLE
Fixes handling of multiple input files

### DIFF
--- a/lib/mix/tasks/recode.ex
+++ b/lib/mix/tasks/recode.ex
@@ -85,8 +85,7 @@ defmodule Mix.Tasks.Recode do
   defp opts!(opts) do
     case OptionParser.parse!(opts, @opts) do
       {opts, []} -> opts
-      {opts, [inputs]} -> Keyword.put(opts, :inputs, inputs)
-      {_opts, args} -> Mix.raise("#{inspect(args)} : Unknown")
+      {opts, inputs} -> Keyword.put(opts, :inputs, inputs)
     end
   end
 

--- a/test/mix/tasks/recode_test.exs
+++ b/test/mix/tasks/recode_test.exs
@@ -33,12 +33,24 @@ defmodule Mix.Tasks.RecodeTest do
   test "mix recode --config priv/config.exs -" do
     expect(RunnerMock, :run, fn config ->
       assert Keyword.keyword?(config)
-      assert config[:inputs] == "-"
+      assert config[:inputs] == ["-"]
 
       ":test" |> source() |> project()
     end)
 
     assert catch_exit(Tasks.Recode.run(["--config", "priv/config.exs", "-"])) == :normal
+  end
+
+  test "mix recode file_1.ex file_2.ex" do
+    expect(RunnerMock, :run, fn config ->
+      assert Keyword.keyword?(config)
+      assert config[:inputs] == ["file_1.ex", "file_2.ex"]
+
+      ":test" |> source() |> project()
+    end)
+
+    assert catch_exit(Tasks.Recode.run(["--config", "priv/config.exs", "file_1.ex", "file_2.ex"])) ==
+             :normal
   end
 
   test "mix recode raises exception for unknown config file" do
@@ -48,8 +60,8 @@ defmodule Mix.Tasks.RecodeTest do
   end
 
   test "mix recode raises exception for unknown arg" do
-    assert_raise Mix.Error, ~s|["inputs", "foo"] : Unknown|, fn ->
-      Tasks.Recode.run(["--config", "priv/config.exs", "inputs", "foo"])
+    assert_raise OptionParser.ParseError, ~r|unknown-arg : Unknown option|, fn ->
+      Tasks.Recode.run(["--config", "priv/config.exs", "--unknown-arg", "inputs", "foo"])
     end
   end
 


### PR DESCRIPTION
Hey there! 🖖 

The `mix recode` task fails when multiple files are passed to it:

```bash
mix recode file_1.exs file_2.exs
** (Mix) ["file_1.exs", "file_2.exs"] : Unknown
```

This pull request fix it by updating the task to handle multiple inputs properly. 