### PR TITLE
Removes unnecessary compile call

### DIFF
--- a/lib/mix/tasks/recode.ex
+++ b/lib/mix/tasks/recode.ex
@@ -58,8 +58,6 @@ defmodule Mix.Tasks.Recode do
   def run(opts) do
     opts = opts!(opts)
 
-    Mix.Task.run("compile")
-
     opts
     |> config!()
     |> validate_config!()


### PR DESCRIPTION
Hello! 🖖 

Since beam_file dependency has been removed from Rewrite and Recode, the compilation step in Recode task is no longer necessary.

Closes #35