### PR TITLE
Print internal exception details when `--verbose`

### DIFF
--- a/lib/recode/issue.ex
+++ b/lib/recode/issue.ex
@@ -38,6 +38,8 @@ defmodule Recode.Issue do
   def new(reporter, meta, info, nil) do
     line = Keyword.get(info, :line)
     column = Keyword.get(info, :column)
-    struct!(Issue, reporter: reporter, line: line, column: column, meta: meta)
+    message = Keyword.get(meta, :message)
+
+    struct!(Issue, reporter: reporter, line: line, column: column, meta: meta, message: message)
   end
 end

--- a/lib/recode/runner/impl.ex
+++ b/lib/recode/runner/impl.ex
@@ -71,7 +71,15 @@ defmodule Recode.Runner.Impl do
     end
   rescue
     error ->
-      Source.add_issue(source, Issue.new(Recode.Runner, task: module, error: error))
+      Source.add_issue(
+        source,
+        Issue.new(
+          Recode.Runner,
+          task: module,
+          error: error,
+          message: Exception.format(:error, error, __STACKTRACE__)
+        )
+      )
   end
 
   defp exclude?(task, source, config) do

--- a/test/recode/formatter_test.exs
+++ b/test/recode/formatter_test.exs
@@ -244,7 +244,9 @@ defmodule Recode.FormatterTest do
       source =
         code
         |> from_string()
-        |> Source.add_issue(Issue.new(Recode.Runner, task: Test, error: :error))
+        |> Source.add_issue(
+          Issue.new(Recode.Runner, task: Test, error: :error, message: "Error Message")
+        )
 
       project = Project.from_sources([source])
 
@@ -257,7 +259,8 @@ defmodule Recode.FormatterTest do
 
       assert output == """
               File: no file
-             Execution of the Test task failed.
+             Execution of the Test task failed with error:
+             Error Message
              """
     end
 

--- a/test/recode/runner/impl_test.exs
+++ b/test/recode/runner/impl_test.exs
@@ -127,7 +127,7 @@ defmodule Recode.Runner.ImplTest do
     test "runs task throwing exception", %{config: config} do
       TaskMock
       |> expect(:run, 2, fn _source, _config ->
-        raise "ups"
+        raise "An Exception Occurred"
       end)
       |> expect(:config, 1, fn :correct -> true end)
 
@@ -138,6 +138,7 @@ defmodule Recode.Runner.ImplTest do
         assert [source, _rest] = Project.sources(project)
         assert [{1, issue}] = source.issues
         assert issue.reporter == Recode.Runner
+        assert String.starts_with?(issue.message, "** (RuntimeError) An Exception Occurred")
       end)
     end
   end


### PR DESCRIPTION
This change adds any error messages raised in the runner to the output when the `--verbose` flag is passed. 

I had to patch something similar in for #54, seems useful to more easily understand weird cases. 