### PR TITLE
Allow optional config for Recode.Task.Format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.3 - 2024/03/..
+
++ Add config for preformatter.
+
 ## 0.7.2 - 2024/02/10
 
 + Fix AST.alias_info fot `alias __MODULE__, as: MyModule`.

--- a/examples/my_code/.recode.exs
+++ b/examples/my_code/.recode.exs
@@ -1,5 +1,5 @@
 [
-  version: "0.7.0",
+  version: "0.7.2",
   # Can also be set/reset with `--autocorrect`/`--no-autocorrect`.
   autocorrect: true,
   # With "--dry" no changes will be written to the files.
@@ -17,6 +17,10 @@
     # Tasks could be added by a tuple of the tasks module name and an options
     # keyword list. A task can be deactivated by `active: false`. The execution of
     # a deactivated task can be forced by calling `mix recode --task ModuleName`.
+    # {Recode.Task.Format, []},
+    # {Recode.Task.Format, config: [formatter: :sourceror]},
+    # {Recode.Task.Format, config: [formatter: :elixir]},
+    # {Recode.Task.Format, active: false},
     {Recode.Task.AliasExpansion, []},
     {Recode.Task.AliasOrder, []},
     {Recode.Task.Dbg, [autocorrect: false]},

--- a/lib/recode/config.ex
+++ b/lib/recode/config.ex
@@ -140,8 +140,8 @@ defmodule Recode.Config do
           path
           |> Code.eval_file()
           |> elem(0)
-          |> default(:tasks)
-          |> update(:inputs)
+          |> default_tasks()
+          |> update_inputs()
 
         {:ok, config}
 
@@ -177,13 +177,23 @@ defmodule Recode.Config do
     if Keyword.has_key?(config, :tasks), do: :ok, else: {:error, :no_tasks}
   end
 
-  defp default(config, :tasks) do
-    Keyword.update!(config, :tasks, fn tasks -> [{Format, []} | tasks] end)
+  defp default_tasks(config) do
+    if has_task?(config, Format) do
+      config
+    else
+      Keyword.update!(config, :tasks, fn tasks -> [{Format, []} | tasks] end)
+    end
   end
 
-  defp update(config, :inputs) do
+  defp update_inputs(config) do
     Keyword.update(config, :inputs, [], fn inputs ->
       inputs |> List.wrap() |> Enum.map(fn input -> GlobEx.compile!(input) end)
     end)
+  end
+
+  defp has_task?(config, module) do
+    config
+    |> Keyword.fetch!(:tasks)
+    |> Keyword.has_key?(module)
   end
 end

--- a/lib/recode/config.ex
+++ b/lib/recode/config.ex
@@ -9,7 +9,7 @@ defmodule Recode.Config do
 
   @config_filename ".recode.exs"
 
-  @config_version "0.7.2"
+  @config_version "0.7.3"
 
   # The minimum version of the config to run recode. This version marks the last
   # breaking change for handle the config.

--- a/lib/recode/task/format.ex
+++ b/lib/recode/task/format.ex
@@ -7,6 +7,21 @@ defmodule Recode.Task.Format do
   This task runs as first task by any `mix recode` call.
   """
 
+  # The task can be configured like other tasks. This configuration is just for
+  # debuging and not part of the documentation.
+  #
+  # The default, formats code with Sourceror:
+  # {Recode.Task.Format, []},
+  #
+  # formats code with Sourceror:
+  # {Recode.Task.Format, config: [formatter: :sourceror]},
+  #
+  # Formats code with the Elixir formatter:
+  #  {Recode.Task.Format, config: [formatter: :elixir]},
+  #
+  # Deactivates the task:
+  # {Recode.Task.Format, active: false},
+
   use Recode.Task, corrector: true, category: :readability
 
   alias Recode.Issue

--- a/lib/recode/task/format.ex
+++ b/lib/recode/task/format.ex
@@ -13,24 +13,77 @@ defmodule Recode.Task.Format do
   alias Recode.Task.Format
   alias Rewrite.Source
 
+  @default_config [formatter: :sourceror]
+  @valid_formatters [:elixir, :sourceror]
+
   @impl Recode.Task
   def run(source, opts) do
     source
     |> Source.Ex.merge_formatter_opts(exclude_plugins: [Recode.FormatterPlugin])
-    |> format(opts[:autocorrect])
+    |> execute(opts[:autocorrect], opts[:formatter])
   end
 
-  defp format(source, true) do
-    Source.update(source, Format, :content, Source.Ex.format(source))
+  defp execute(source, true, formatter) do
+    Source.update(source, Format, :content, format(source, formatter))
   end
 
-  defp format(source, false) do
-    case Source.get(source, :content) == Source.Ex.format(source) do
+  defp execute(source, false, formatter) do
+    case Source.get(source, :content) == format(source, formatter) do
       true ->
         source
 
       false ->
         Source.add_issue(source, Issue.new(Format, "The file is not formatted."))
+    end
+  end
+
+  defp format(source, :sourceror) do
+    Source.Ex.format(source)
+  end
+
+  defp format(source, :elixir) do
+    opts = Keyword.get(source.filetype.opts, :formatter_opts, [])
+
+    source
+    |> Source.get(:content)
+    |> Code.format_string!(opts)
+    |> IO.iodata_to_binary()
+  end
+
+  @impl Recode.Task
+  def init([]), do: {:ok, @default_config}
+
+  def init(config) do
+    with {:error, reason} <- validate(config) do
+      case reason do
+        {:unknown, keys} ->
+          {:error,
+           """
+           Unknown options: #{inspect(keys)}.\
+           """}
+
+        {:invalid_formatter, formatter} ->
+          {:error,
+           """
+           The option formatter expects :elixir or :sourceror, got: #{inspect(formatter)}.\
+           """}
+      end
+    end
+  end
+
+  defp validate(config) do
+    with {:ok, config} <- validate_keys(config) do
+      if config[:formatter] in @valid_formatters do
+        {:ok, config}
+      else
+        {:error, {:invalid_formatter, config[:formatter]}}
+      end
+    end
+  end
+
+  defp validate_keys(config) do
+    with {:error, keys} <- Keyword.validate(config, @default_config) do
+      {:error, {:unknown, keys}}
     end
   end
 end

--- a/lib/recode/task/format.ex
+++ b/lib/recode/task/format.ex
@@ -18,6 +18,8 @@ defmodule Recode.Task.Format do
 
   @impl Recode.Task
   def run(source, opts) do
+    opts = Keyword.merge(opts, @default_config)
+
     source
     |> Source.Ex.merge_formatter_opts(exclude_plugins: [Recode.FormatterPlugin])
     |> execute(opts[:autocorrect], opts[:formatter])
@@ -82,7 +84,7 @@ defmodule Recode.Task.Format do
   end
 
   defp validate_keys(config) do
-    with {:error, keys} <- Keyword.validate(config, @default_config) do
+    with {:error, keys} <- Keyword.validate(config, [:autocorrect] ++ @default_config) do
       {:error, {:unknown, keys}}
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Recode.MixProject do
   use Mix.Project
 
-  @version "0.7.2"
+  @version "0.7.3"
   @source_url "https://github.com/hrzndhrn/recode"
 
   def project do


### PR DESCRIPTION
closes #86 

@szymonkozak you can now add an optional config for `Recode.Task.Format`:
```elixir
...
  tasks: [
    # the default, formats code with Sourceror 
    # {Recode.Task.Format, []}, 

    # formats code with Sourceror 
    # {Recode.Task.Format, config: [formatter: :sourceror]}, 
 
    # formats code with the Elixir formatter
    {Recode.Task.Format, config: [formatter: :elixir]}, 
 
    # deactivates the task
    # {Recode.Task.Format, active: false}, 
...
```