### PR TITLE
Remove parens

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,5 @@
 # Used by "mix format"
 [
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  locals_without_parens: [assert: 1]
 ]

--- a/lib/recode/task/remove_parens.ex
+++ b/lib/recode/task/remove_parens.ex
@@ -2,17 +2,13 @@ defmodule Recode.Task.RemoveParens do
   @shortdoc "Removes parens from locals without parens"
 
   @moduledoc """
-  Redudant booleans make code needlesly verbose.
+  Don't use parens for functions that don't need them.
 
           # preferred
-          foo == bar
+          assert true == true
 
           # not preferred
-          if foo == bar do
-            true
-          else
-            false
-          end
+          assert(true == true)
 
   This task rewrites the code when `mix recode` runs with `autocorrect: true`.
   """

--- a/lib/recode/task/remove_parens.ex
+++ b/lib/recode/task/remove_parens.ex
@@ -42,18 +42,6 @@ defmodule Recode.Task.RemoveParens do
     end
   end
 
-  defp local_without_parens?(locals_without_parens, fun, [_ | _] = args) do
-    arity = length(args)
-
-    Enum.any?(locals_without_parens, fn
-      {^fun, :*} -> true
-      {^fun, ^arity} -> true
-      _other -> false
-    end)
-  end
-
-  defp local_without_parens?(_locals_without_parens, _fun, _args), do: false
-
   defp remove_parens(
          locals_without_parens,
          %Zipper{node: {fun, meta, args}} = zipper,
@@ -66,7 +54,6 @@ defmodule Recode.Task.RemoveParens do
         {Zipper.replace(zipper, node), issues}
       else
         issue = Issue.new(RemoveParens, "Unncecessary parens")
-
         {zipper, [issue | issues]}
       end
     else
@@ -77,4 +64,16 @@ defmodule Recode.Task.RemoveParens do
   defp remove_parens(_, zipper, issues, _) do
     {zipper, issues}
   end
+
+  defp local_without_parens?(locals_without_parens, fun, [_ | _] = args) do
+    arity = length(args)
+
+    Enum.any?(locals_without_parens, fn
+      {^fun, :*} -> true
+      {^fun, ^arity} -> true
+      _other -> false
+    end)
+  end
+
+  defp local_without_parens?(_locals_without_parens, _fun, _args), do: false
 end

--- a/lib/recode/task/remove_parens.ex
+++ b/lib/recode/task/remove_parens.ex
@@ -22,7 +22,7 @@ defmodule Recode.Task.RemoveParens do
 
   @impl Recode.Task
   def run(source, opts) do
-    formatter_opts = Mix.Tasks.Format.formatter_opts_for_file(".mix.exs")
+    formatter_opts = Mix.Tasks.Format.formatter_opts_for_file(source.path || "nofile")
     locals_without_parens = Keyword.get(formatter_opts, :locals_without_parens, [])
 
     {zipper, issues} =

--- a/lib/recode/task/remove_parens.ex
+++ b/lib/recode/task/remove_parens.ex
@@ -46,21 +46,28 @@ defmodule Recode.Task.RemoveParens do
     end
   end
 
-  defp remove_parens(locals_without_parens, %Zipper{} = zipper, issues, true) do
+  defp remove_parens(
+         locals_without_parens,
+         %Zipper{node: {fun, _, args} = node} = zipper,
+         issues,
+         true
+       ) do
     node =
-      with {fun, _, args} = node <- Zipper.node(zipper) do
-        Enum.reduce(locals_without_parens, node, fn
-          {^fun, arity}, node when length(args) == arity ->
-            {fun, meta, args} = node
-            meta = Keyword.delete(meta, :closing)
+      Enum.reduce(locals_without_parens, node, fn
+        {^fun, arity}, node when length(args) == arity ->
+          {fun, meta, args} = node
+          meta = Keyword.delete(meta, :closing)
 
-            {fun, meta, args}
+          {fun, meta, args}
 
-          _, node ->
-            node
-        end)
-      end
+        _, node ->
+          node
+      end)
 
     {%Zipper{zipper | node: node}, issues}
+  end
+
+  defp remove_parens(_, zipper, issues, _) do
+    {zipper, issues}
   end
 end

--- a/lib/recode/task/remove_parens.ex
+++ b/lib/recode/task/remove_parens.ex
@@ -1,0 +1,66 @@
+defmodule Recode.Task.RemoveParens do
+  @shortdoc "Removes parens from locals without parens"
+
+  @moduledoc """
+  Redudant booleans make code needlesly verbose.
+
+          # preferred
+          foo == bar
+
+          # not preferred
+          if foo == bar do
+            true
+          else
+            false
+          end
+
+  This task rewrites the code when `mix recode` runs with `autocorrect: true`.
+  """
+
+  use Recode.Task, corrector: true, category: :readability
+
+  # alias Recode.Issue
+  alias Recode.Task.UnnecessaryIfUnless
+  alias Rewrite.Source
+  alias Sourceror.Zipper
+
+  @impl Recode.Task
+  def run(source, opts) do
+    formatter_opts = Mix.Tasks.Format.formatter_opts_for_file(".mix.exs")
+    locals_without_parens = Keyword.get(formatter_opts, :locals_without_parens, [])
+
+    {zipper, issues} =
+      source
+      |> Source.get(:quoted)
+      |> Zipper.zip()
+      |> Zipper.traverse([], fn zipper, issues ->
+        remove_parens(locals_without_parens, zipper, issues, opts[:autocorrect])
+      end)
+
+    case opts[:autocorrect] do
+      true ->
+        Source.update(source, UnnecessaryIfUnless, :quoted, Zipper.root(zipper))
+
+      false ->
+        Source.add_issues(source, issues)
+    end
+  end
+
+  defp remove_parens(locals_without_parens, %Zipper{} = zipper, issues, true) do
+    node =
+      with {fun, _, args} = node <- Zipper.node(zipper) do
+        Enum.reduce(locals_without_parens, node, fn
+          {^fun, arity}, node when length(args) == arity ->
+            {fun, meta, args} = node
+            meta = Keyword.delete(meta, :closing)
+
+            {fun, meta, args}
+
+          _, node ->
+            node
+        end)
+      end
+
+    {%Zipper{zipper | node: node}, issues}
+  end
+end

--- a/test/recode/task/remove_parens_test.exs
+++ b/test/recode/task/remove_parens_test.exs
@@ -30,4 +30,12 @@ defmodule Recode.Task.RemoveParensTest do
     |> run_task(RemoveParens, autocorrect: true)
     |> assert_code(expected)
   end
+
+  test "adds issue" do
+    """
+    assert(true == false)
+    """
+    |> run_task(RemoveParens, autocorrect: false)
+    |> assert_issue()
+  end
 end

--- a/test/recode/task/remove_parens_test.exs
+++ b/test/recode/task/remove_parens_test.exs
@@ -1,5 +1,5 @@
 defmodule Recode.Task.RemoveParensTest do
-  use RecodeCase, async: true
+  use RecodeCase, async: false
 
   alias Recode.Task.RemoveParens
 

--- a/test/recode/task/remove_parens_test.exs
+++ b/test/recode/task/remove_parens_test.exs
@@ -1,0 +1,33 @@
+defmodule Recode.Task.RemoveParensTest do
+  use RecodeCase
+
+  alias Recode.Task.RemoveParens
+
+  test "removes parens" do
+    code = """
+    assert(true == false)
+    """
+
+    expected = """
+    assert true == false
+    """
+
+    code
+    |> run_task(RemoveParens, autocorrect: true)
+    |> assert_code(expected)
+  end
+
+  test "respects arity" do
+    code = """
+    assert(true, "assert/2 is not in locals_without_parens")
+    """
+
+    expected = """
+    assert(true, "assert/2 is not in locals_without_parens")
+    """
+
+    code
+    |> run_task(RemoveParens, autocorrect: true)
+    |> assert_code(expected)
+  end
+end

--- a/test/recode/task/remove_parens_test.exs
+++ b/test/recode/task/remove_parens_test.exs
@@ -34,39 +34,13 @@ defmodule Recode.Task.RemoveParensTest do
     end)
   end
 
-  test "removes parens" do
-    code = """
-    assert(true == false)
-    """
-
-    expected = """
-    assert true == false
-    """
-
-    code
-    |> run_task(RemoveParens, autocorrect: true)
-    |> assert_code(expected)
-  end
-
-  test "respects arity" do
-    code = """
-    assert(true, "assert/2 is not in locals_without_parens")
-    """
-
-    expected = """
-    assert(true, "assert/2 is not in locals_without_parens")
-    """
-
-    code
-    |> run_task(RemoveParens, autocorrect: true)
-    |> assert_code(expected)
-  end
-
-  test "adds issue" do
-    """
-    assert(true == false)
-    """
-    |> run_task(RemoveParens, autocorrect: false)
-    |> assert_issue()
+  test "adds issue", %{tmp_dir: tmp_dir} do
+    File.cd!(tmp_dir, fn ->
+      """
+      x = foo(bar)
+      """
+      |> run_task(RemoveParens, autocorrect: false)
+      |> assert_issue()
+    end)
   end
 end

--- a/test/recode/task/remove_parens_test.exs
+++ b/test/recode/task/remove_parens_test.exs
@@ -1,7 +1,38 @@
 defmodule Recode.Task.RemoveParensTest do
-  use RecodeCase
+  use RecodeCase, async: true
 
   alias Recode.Task.RemoveParens
+
+  @moduletag :tmp_dir
+
+  setup context do
+    File.write("#{context.tmp_dir}/.formatter.exs", """
+    [
+      inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
+      locals_without_parens: [foo: 1, bar: 2]
+    ]
+    """)
+
+    {:ok, context}
+  end
+
+  test "remove parens", %{tmp_dir: tmp_dir} do
+    File.cd!(tmp_dir, fn ->
+      code = """
+      x = foo(bar(y))
+      bar(y, x)
+      """
+
+      expected = """
+      x = foo bar(y)
+      bar y, x
+      """
+
+      code
+      |> run_task(RemoveParens, autocorrect: true)
+      |> assert_code(expected)
+    end)
+  end
 
   test "removes parens" do
     code = """


### PR DESCRIPTION
Here's my first draft of removing parens.

I should be functionally complete though I still have several things to do.

Most importantly, I'm looking for some guidance on testing and general file to use to get the config opts.  I'm using `Mix.Tasks.Format.formatter_opts_for_file("mix.exs")` in the implementation and have added a non-exported `locals_without_parens: [assert: 1]` to this project's `.formatter.exs` just for testing purposes.  I don't love this, but since I have no clean way to do DI I need to either do it this way, use a mock (which means adding a library), _or_ do some env-checking.  Perhaps there is another way I'm not thinking of.  What do you think?

Other than that I need to:

- Refactor.
- Add docs.
- Add more tests.

And once again I'd love some guidance on what to call this corrector.

Thanks!