### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 
 ## 0.7.2 - 2024/02/10
 
-+ Fix `Recode.AST.alias_info` fot `alias __MODULE__, as: MyModule`.
++ Fix `Recode.AST.alias_info` for `alias __MODULE__, as: MyModule`.
 
 ## 0.7.1 - 2024/01/09
 
@@ -50,7 +50,7 @@
 
 ## 0.6.5 - 2023/10/09
 
-+ Start `:recode` appliations in `mix recode` task.
++ Start `:recode` applications in `mix recode` task.
 
 ## 0.6.4 - 2023/09/15
 
@@ -135,7 +135,7 @@
 
 ## 0.3.0 - 2022/08/28
 
-+ Rename `Recode.Taks.SameLine` to `Recode.Task.EnforceLineLength`.
++ Rename `Recode.Task.SameLine` to `Recode.Task.EnforceLineLength`.
 
 ## 0.2.0 - 2022/08/21
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Design tasks:
 TagFIXME            # Checker   - Checks if there are FIXME tags in the sources.
 TagTODO             # Checker   - Checks if there are TODO tags in the sources.
 Readability tasks:
-AliasExpansion      # Corrector - Exapnds multi aliases to separate aliases.
+AliasExpansion      # Corrector - Expands multi aliases to separate aliases.
 AliasOrder          # Corrector - Checks if aliases are sorted alphabetically.
 EnforceLineLength   # Corrector - Forces expressions to one line.
 Format              # Corrector - Does the same as `mix format`.

--- a/lib/mix/tasks/recode.help.ex
+++ b/lib/mix/tasks/recode.help.ex
@@ -2,7 +2,7 @@ defmodule Mix.Tasks.Recode.Help do
   @shortdoc "Lists recode tasks"
 
   @moduledoc """
-  Lists all availbale recode tasks with a short description or prints the
+  Lists all available recode tasks with a short description or prints the
   documentation for a given recode task.
 
   To print the documentation of a task run `mix recode.help {task-name}`. As a

--- a/lib/mix/tasks/recode.update.config.ex
+++ b/lib/mix/tasks/recode.update.config.ex
@@ -4,10 +4,10 @@ defmodule Mix.Tasks.Recode.Update.Config do
   @moduledoc """
   #{@shortdoc}.
 
-  The task merges the exsiting config into the actual config and updates the
+  The task merges the existing config into the actual config and updates the
   version.  Using this task preserves changes in the actual config and adds new values.
 
-  The acutal default config:
+  The actual default config:
   ```elixir
   #{Recode.Config.to_string()}
   ```

--- a/lib/recode/ast.ex
+++ b/lib/recode/ast.ex
@@ -1,10 +1,10 @@
 defmodule Recode.AST do
   @moduledoc """
-  This module provides functions to get informations from the AST and to
+  This module provides functions to get information from the AST and to
   manipulate the AST.
 
   Most of the functions in this module require an AST with additional
-  informations. This information is provided by `Sourceror` or
+  information. This information is provided by `Sourceror` or
   `Code.string_to_quoted/2` with the options
   ```elixir
   [

--- a/lib/recode/config.ex
+++ b/lib/recode/config.ex
@@ -167,7 +167,7 @@ defmodule Recode.Config do
   end
 
   @doc """
-  Reads the `Recode` cofiguration from the given `path`.
+  Reads the `Recode` configuration from the given `path`.
   """
   @spec read(Path.t()) :: {:ok, config()} | {:error, :not_found}
   def read(path \\ @config_filename) when is_binary(path) do

--- a/lib/recode/runner/impl.ex
+++ b/lib/recode/runner/impl.ex
@@ -194,7 +194,7 @@ defmodule Recode.Runner.Impl do
       )
   end
 
-  # For now, all sources without a filetype Source.Ex are direclty excluded.
+  # For now, all sources without a filetype Source.Ex are directly excluded.
   # For the Source.Ex sources we check whether the source is excluded.
   defp exclude?(task, %Source{filetype: %Source.Ex{}} = source, config) do
     config
@@ -246,10 +246,10 @@ defmodule Recode.Runner.Impl do
 
   defp exclude_reading(config) do
     config_file = get_cli_opts(config, :config, ".recode.exs")
-    config_timestemp = Timestamp.for_file(config_file)
+    config_timestamp = Timestamp.for_file(config_file)
 
     case Manifest.read(config) do
-      {timestamp, ^config_file, paths} when timestamp > config_timestemp ->
+      {timestamp, ^config_file, paths} when timestamp > config_timestamp ->
         fn path ->
           cond do
             path in paths -> false

--- a/lib/recode/task/alias_expansion.ex
+++ b/lib/recode/task/alias_expansion.ex
@@ -1,5 +1,5 @@
 defmodule Recode.Task.AliasExpansion do
-  @shortdoc "Exapnds multi aliases to separate aliases."
+  @shortdoc "Expands multi aliases to separate aliases."
 
   @moduledoc """
   Multi aliases makes module uses harder to search for in large code bases.

--- a/lib/recode/task/format.ex
+++ b/lib/recode/task/format.ex
@@ -8,7 +8,7 @@ defmodule Recode.Task.Format do
   """
 
   # The task can be configured like other tasks. This configuration is just for
-  # debuging and not part of the documentation.
+  # debugging and not part of the documentation.
   #
   # The default, formats code with Sourceror:
   # {Recode.Task.Format, []},

--- a/lib/recode/task/tag_fixme.ex
+++ b/lib/recode/task/tag_fixme.ex
@@ -4,7 +4,7 @@ defmodule Recode.Task.TagFIXME do
   @moduledoc """
   #{@shortdoc}
 
-  FIXME tags in comments and docs are used as a reminder and should be handeld in
+  FIXME tags in comments and docs are used as a reminder and should be handled in
   the near future.
 
   ## Examples

--- a/lib/recode/task/tag_todo.ex
+++ b/lib/recode/task/tag_todo.ex
@@ -4,7 +4,7 @@ defmodule Recode.Task.TagTODO do
   @moduledoc """
   #{@shortdoc}
 
-  TODO tags in comments and docs are used as a reminder and should be handeld in
+  TODO tags in comments and docs are used as a reminder and should be handled in
   the near future.
 
   ## Examples

--- a/lib/recode/task/unnecessary_if_unless.ex
+++ b/lib/recode/task/unnecessary_if_unless.ex
@@ -2,7 +2,7 @@ defmodule Recode.Task.UnnecessaryIfUnless do
   @shortdoc "Removes redundant booleans"
 
   @moduledoc """
-  Redudant booleans make code needlesly verbose.
+  Redundant booleans make code needlessly verbose.
 
           # preferred
           foo == bar
@@ -29,13 +29,13 @@ defmodule Recode.Task.UnnecessaryIfUnless do
       |> Source.get(:quoted)
       |> Zipper.zip()
       |> Zipper.traverse([], fn zipper, issues ->
-        remove_unecessary_if_unless(zipper, issues, opts[:autocorrect])
+        remove_unnecessary_if_unless(zipper, issues, opts[:autocorrect])
       end)
 
     update_source(source, opts, quoted: zipper, issues: issues)
   end
 
-  defp remove_unecessary_if_unless(
+  defp remove_unnecessary_if_unless(
          %Zipper{node: {conditional, meta, body}} = zipper,
          issues,
          true
@@ -52,7 +52,7 @@ defmodule Recode.Task.UnnecessaryIfUnless do
     end
   end
 
-  defp remove_unecessary_if_unless(
+  defp remove_unnecessary_if_unless(
          %Zipper{node: {conditional, meta, body}} = zipper,
          issues,
          false
@@ -72,7 +72,7 @@ defmodule Recode.Task.UnnecessaryIfUnless do
     {zipper, issues}
   end
 
-  defp remove_unecessary_if_unless(zipper, issues, _autocorrect), do: {zipper, issues}
+  defp remove_unnecessary_if_unless(zipper, issues, _autocorrect), do: {zipper, issues}
 
   defp extract(
          [

--- a/test/recode/context_test.exs
+++ b/test/recode/context_test.exs
@@ -195,7 +195,7 @@ defmodule Recode.ContextTest do
       assert output =~ ~r/^234: requirements:.*Traverse.Pluto/m
     end
 
-    test "traveses script with vars named alias, import, etc.." do
+    test "traverses script with vars named alias, import, etc.." do
       src = File.read!("test/fixtures/context/vars.exs")
 
       output =
@@ -216,7 +216,7 @@ defmodule Recode.ContextTest do
       assert output == File.read!("test/fixtures/context/vars.exs.output")
     end
 
-    test "traveses module with vars named alias, import, etc.." do
+    test "traverses module with vars named alias, import, etc.." do
       src = File.read!("test/fixtures/context/vars.ex")
 
       output =

--- a/test/recode/task/enforce_line_length_test.exs
+++ b/test/recode/task/enforce_line_length_test.exs
@@ -18,7 +18,7 @@ defmodule Recode.Task.EnforceLineLengthTest do
       foo: 42
     }
 
-    assert formated?(code)
+    assert formatted?(code)
 
     code
     |> run_task(EnforceLineLength, autocorrect: true)
@@ -62,7 +62,7 @@ defmodule Recode.Task.EnforceLineLengthTest do
     [:a, :b, :c]
     """
 
-    assert formated?(code)
+    assert formatted?(code)
 
     code
     |> run_task(EnforceLineLength, autocorrect: true)
@@ -80,7 +80,7 @@ defmodule Recode.Task.EnforceLineLengthTest do
     true and false and x
     """
 
-    assert formated?(code)
+    assert formatted?(code)
 
     code
     |> run_task(EnforceLineLength, autocorrect: true)
@@ -101,7 +101,7 @@ defmodule Recode.Task.EnforceLineLengthTest do
     1 + 2 - 3 / 4 * 5 + 6
     """
 
-    assert formated?(code)
+    assert formatted?(code)
 
     code
     |> run_task(EnforceLineLength, autocorrect: true)
@@ -127,7 +127,7 @@ defmodule Recode.Task.EnforceLineLengthTest do
     end
     """
 
-    assert formated?(code)
+    assert formatted?(code)
 
     code
     |> run_task(EnforceLineLength, autocorrect: true)
@@ -148,7 +148,7 @@ defmodule Recode.Task.EnforceLineLengthTest do
     end
     """
 
-    assert formated?(code)
+    assert formatted?(code)
 
     code
     |> run_task(EnforceLineLength, autocorrect: true)
@@ -176,7 +176,7 @@ defmodule Recode.Task.EnforceLineLengthTest do
     end
     """
 
-    assert formated?(code)
+    assert formatted?(code)
 
     code
     |> run_task(EnforceLineLength, autocorrect: true)
@@ -211,7 +211,7 @@ defmodule Recode.Task.EnforceLineLengthTest do
     end
     """
 
-    assert formated?(code)
+    assert formatted?(code)
 
     code
     |> run_task(EnforceLineLength, autocorrect: true)
@@ -247,7 +247,7 @@ defmodule Recode.Task.EnforceLineLengthTest do
     end
     """
 
-    assert formated?(code)
+    assert formatted?(code)
 
     code
     |> run_task(EnforceLineLength, autocorrect: true)
@@ -265,7 +265,7 @@ defmodule Recode.Task.EnforceLineLengthTest do
     fn x -> {:ok, x} end
     """
 
-    assert formated?(code)
+    assert formatted?(code)
 
     code
     |> run_task(EnforceLineLength, autocorrect: true)
@@ -298,7 +298,7 @@ defmodule Recode.Task.EnforceLineLengthTest do
     fn x -> {:ok, x} end
     """
 
-    assert formated?(code)
+    assert formatted?(code)
 
     code
     |> run_task(EnforceLineLength, autocorrect: true)
@@ -336,7 +336,7 @@ defmodule Recode.Task.EnforceLineLengthTest do
     end
     """
 
-    assert formated?(code)
+    assert formatted?(code)
 
     code
     |> run_task(EnforceLineLength, ignore: [:fn], autocorrect: true)
@@ -367,7 +367,7 @@ defmodule Recode.Task.EnforceLineLengthTest do
     end
     """
 
-    assert formated?(code)
+    assert formatted?(code)
 
     code
     |> run_task(EnforceLineLength, autocorrect: true)
@@ -400,7 +400,7 @@ defmodule Recode.Task.EnforceLineLengthTest do
     end
     """
 
-    assert formated?(code)
+    assert formatted?(code)
 
     code
     |> run_task(EnforceLineLength, ignore: [:fn], autocorrect: true)
@@ -436,7 +436,7 @@ defmodule Recode.Task.EnforceLineLengthTest do
     end
     """
 
-    assert formated?(code)
+    assert formatted?(code)
 
     code
     |> run_task(EnforceLineLength, skip: [:assert_raise], autocorrect: true)

--- a/test/recode/task/filter_count_test.exs
+++ b/test/recode/task/filter_count_test.exs
@@ -198,7 +198,7 @@ defmodule Recode.Task.FilterCountTest do
       |> assert_code(expected)
     end
 
-    test "corrects code when Enum.count gets a pipline ending with Enum.filter as argument" do
+    test "corrects code when Enum.count gets a pipeline ending with Enum.filter as argument" do
       code = """
       def foo(arg) do
         Enum.count(arg |> Enum.reverse() |> Enum.filter(fn x -> rem(x, 2) == 0 end))
@@ -361,7 +361,7 @@ defmodule Recode.Task.FilterCountTest do
       |> assert_issue()
     end
 
-    test "reports issue when Enum.count gets a pipline ending with Enum.filter as argument" do
+    test "reports issue when Enum.count gets a pipeline ending with Enum.filter as argument" do
       """
       def foo(arg) do
         Enum.count(arg |> Enum.reverse() |> Enum.filter(fn x -> rem(x, 2) == 0 end))

--- a/test/recode/task/moduledoc_test.exs
+++ b/test/recode/task/moduledoc_test.exs
@@ -4,7 +4,7 @@ defmodule Recode.Task.ModuledocTest do
   alias Recode.Task.Moduledoc
 
   describe "run/1 not raises an issue" do
-    test "when no defmodule is availabel" do
+    test "when no defmodule is available" do
       """
       def foo(x) do
         {:ok, x}

--- a/test/recode/task/nesting_test.exs
+++ b/test/recode/task/nesting_test.exs
@@ -55,7 +55,7 @@ defmodule Recode.Task.NestingTest do
       |> refute_issues()
     end
 
-    test "trigers not when max_depth is great enough" do
+    test "triggers not when max_depth is great enough" do
       """
       defmodule Sample do
         def function(x, y) do
@@ -78,7 +78,7 @@ defmodule Recode.Task.NestingTest do
     # cases raising issues
     #
 
-    test "trigers when max depth is exceeded" do
+    test "triggers when max depth is exceeded" do
       """
       defmodule Sample do
         def something(x, y) do
@@ -97,7 +97,7 @@ defmodule Recode.Task.NestingTest do
       |> assert_issue_with(reporter: Nesting, line: 5)
     end
 
-    test "trigers once when max depth is exceeded by more then one step" do
+    test "triggers once when max depth is exceeded by more then one step" do
       """
       defmodule Sample do
         def something(x, y) do
@@ -121,7 +121,7 @@ defmodule Recode.Task.NestingTest do
       |> assert_issue_with(reporter: Nesting, line: 5)
     end
 
-    test "trigers with a greate max_depth" do
+    test "triggers with a greater max_depth" do
       """
       defmodule Sample do
         def something(x, y) do
@@ -145,7 +145,7 @@ defmodule Recode.Task.NestingTest do
       |> assert_issue_with(reporter: Nesting, line: 7)
     end
 
-    test "trigers twice when max depth is exceeded twice" do
+    test "triggers twice when max depth is exceeded twice" do
       """
       defmodule Sample do
         def something(x, y) do
@@ -173,7 +173,7 @@ defmodule Recode.Task.NestingTest do
       |> assert_issues(2)
     end
 
-    test "trigers in an anonymous function" do
+    test "triggers in an anonymous function" do
       """
       defmodule Sample do
         def something(x) do

--- a/test/support/recode_case.ex
+++ b/test/support/recode_case.ex
@@ -147,7 +147,7 @@ defmodule RecodeCase do
     end
   end
 
-  def formated?(code) do
+  def formatted?(code) do
     String.trim(code) == code |> Code.format_string!() |> IO.iodata_to_binary()
   end
 


### PR DESCRIPTION
Changes detected running: `typos --format brief --hidden`

Typos: https://github.com/crate-ci/typos

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed multiple spelling and grammar errors in documentation strings, module descriptions, and changelog entries throughout the codebase.

* **Tests**
  * Corrected test descriptions and utility functions with typo fixes for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->